### PR TITLE
Add Docker Compose for local queue testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,27 @@ Install dependencies once:
 npm install
 ```
 
+## Running Messaging Services Locally
+
+Start RabbitMQ, NATS and a local SQS implementation using Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
+This will expose the following ports:
+
+- RabbitMQ: `5672` (AMQP) and `15672` (management UI)
+- NATS: `4222`
+- LocalStack (SQS): `4566`
+
+Set the following environment variables when running the scripts to connect to
+these local services:
+
+- `RABBITMQ_URL=amqp://localhost`
+- `NATS_URL=nats://localhost:4222`
+- `AWS_REGION=us-east-1` and `SQS_ENDPOINT=http://localhost:4566`
+
 ## RabbitMQ Test
 
 Set `RABBITMQ_URL` to your RabbitMQ server (for example from AmazonMQ) and optionally `RABBITMQ_QUEUE`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+
+  nats:
+    image: nats:2
+    ports:
+      - "4222:4222"
+      - "8222:8222"
+
+  localstack:
+    image: localstack/localstack
+    environment:
+      - SERVICES=sqs
+    ports:
+      - "4566:4566"

--- a/sqs_test.js
+++ b/sqs_test.js
@@ -9,8 +9,12 @@ const {
 async function main() {
   const queueName = process.env.SQS_QUEUE || 'test-queue';
   const region = process.env.AWS_REGION || 'us-east-1';
+  const endpoint = process.env.SQS_ENDPOINT;
 
-  const client = new SQSClient({ region });
+  const client = new SQSClient({
+    region,
+    ...(endpoint ? { endpoint } : {}),
+  });
 
   const { QueueUrl } = await client.send(new CreateQueueCommand({ QueueName: queueName }));
   const message = 'Hello SQS';


### PR DESCRIPTION
## Summary
- support overriding SQS endpoint in example script
- provide a docker-compose file for RabbitMQ, NATS and LocalStack
- document how to run messaging services locally

## Testing
- `npm install --silent`
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_686690188ab083289bc5e8196e1c7722