### PR TITLE
Add rate-based message sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ these local services:
 - `AWS_REGION=us-east-1`
 - `SQS_ENDPOINT=http://localhost:4566`
 - optionally `AWS_ACCESS_KEY_ID=test` and `AWS_SECRET_ACCESS_KEY=test`
+- `MESSAGE_RATE=100` number of messages per second (default)
+- `TEST_DURATION_SEC=600` duration in seconds (default 10 minutes)
 
 ## RabbitMQ Test
 
 Set `RABBITMQ_URL` to your RabbitMQ server (for example from AmazonMQ) and optionally `RABBITMQ_QUEUE`.
 
-Run:
+Run (you can override `MESSAGE_RATE` and `TEST_DURATION_SEC`):
 
 ```bash
 node rabbitmq_test.js
@@ -58,7 +60,7 @@ node rabbitmq_test.js
 
 Configure AWS credentials and set `AWS_REGION` and optionally `SQS_QUEUE`.
 
-Run:
+Run (you can override `MESSAGE_RATE` and `TEST_DURATION_SEC`):
 
 ```bash
 node sqs_test.js
@@ -68,7 +70,7 @@ node sqs_test.js
 
 Set `NATS_URL` to your NATS server and optionally `NATS_SUBJECT`.
 
-Run:
+Run (you can override `MESSAGE_RATE` and `TEST_DURATION_SEC`):
 
 ```bash
 node nats_test.js

--- a/nats_test.js
+++ b/nats_test.js
@@ -1,24 +1,64 @@
 const { connect, StringCodec } = require('nats');
+const { percentile } = require('./util');
 
 async function main() {
   const url = process.env.NATS_URL || 'nats://localhost:4222';
   const subject = process.env.NATS_SUBJECT || 'test';
 
-  const nc = await connect({ servers: url });
+  const rate = parseInt(process.env.MESSAGE_RATE || '100', 10);
+  const durationSec = parseInt(process.env.TEST_DURATION_SEC || '600', 10);
+  const count = parseInt(
+    process.env.MESSAGE_COUNT || (rate * durationSec).toString(),
+    10
+  );
+
+  let nc;
+  try {
+    nc = await connect({ servers: url });
+    console.log('NATS available');
+  } catch (err) {
+    console.error('NATS unavailable', err);
+    return;
+  }
   const sc = StringCodec();
 
+  let received = 0;
+  const latencies = [];
+  const seen = new Set();
+  let duplicates = 0;
+
+  const start = Date.now();
   const sub = nc.subscribe(subject);
   (async () => {
     for await (const m of sub) {
-      console.log('Received:', sc.decode(m.data));
-      sub.unsubscribe();
-      await nc.drain();
+      const { id, ts } = JSON.parse(sc.decode(m.data));
+      const now = Date.now();
+      latencies.push(now - ts);
+      if (seen.has(id)) duplicates++; else seen.add(id);
+      received++;
+      if (received === count) {
+        const duration = (now - start) / 1000;
+        console.log('p95 latency ms:', percentile(latencies, 95));
+        console.log('duplicates:', duplicates);
+        console.log('throughput msg/s:', (received / duration).toFixed(2));
+        sub.unsubscribe();
+        await nc.drain();
+      }
     }
   })();
 
-  const message = 'Hello NATS';
-  nc.publish(subject, sc.encode(message));
-  console.log('Sent:', message);
+  let sent = 0;
+  const sendInterval = setInterval(() => {
+    for (let i = 0; i < rate && sent < count; i++) {
+      const payload = { id: sent, ts: Date.now() };
+      nc.publish(subject, sc.encode(JSON.stringify(payload)));
+      sent++;
+    }
+    if (sent >= count) {
+      clearInterval(sendInterval);
+      console.log(`Sent ${sent} messages, waiting for receipts...`);
+    }
+  }, 1000);
 }
 
 main().catch(err => {

--- a/rabbitmq_test.js
+++ b/rabbitmq_test.js
@@ -1,26 +1,73 @@
 const amqp = require('amqplib');
+const { percentile } = require('./util');
 
 async function main() {
   const url = process.env.RABBITMQ_URL || 'amqp://localhost';
   const queue = process.env.RABBITMQ_QUEUE || 'test';
 
-  const connection = await amqp.connect(url);
+  const rate = parseInt(process.env.MESSAGE_RATE || '100', 10);
+  const durationSec = parseInt(process.env.TEST_DURATION_SEC || '600', 10);
+  const count = parseInt(
+    process.env.MESSAGE_COUNT || (rate * durationSec).toString(),
+    10
+  );
+
+  let connection;
+  try {
+    connection = await amqp.connect(url);
+    console.log('RabbitMQ available');
+  } catch (err) {
+    console.error('RabbitMQ unavailable', err);
+    return;
+  }
+
   const channel = await connection.createChannel();
   await channel.assertQueue(queue, { durable: true });
 
-  const message = 'Hello RabbitMQ';
-  await channel.sendToQueue(queue, Buffer.from(message), { persistent: true });
-  console.log('Sent:', message);
+  let sent = 0;
+  let received = 0;
+  const latencies = [];
+  const seen = new Set();
+  let duplicates = 0;
 
-  await channel.consume(queue, msg => {
-    if (msg !== null) {
-      console.log('Received:', msg.content.toString());
-      channel.ack(msg);
-      connection.close();
+  const start = Date.now();
+
+  await channel.consume(
+    queue,
+    (msg) => {
+      if (msg !== null) {
+        const { id, ts } = JSON.parse(msg.content.toString());
+        const now = Date.now();
+        latencies.push(now - ts);
+        if (seen.has(id)) duplicates++;
+        seen.add(id);
+        received++;
+        channel.ack(msg);
+        if (received === count) {
+          const duration = (now - start) / 1000;
+          console.log('p95 latency ms:', percentile(latencies, 95));
+          console.log('duplicates:', duplicates);
+          console.log('throughput msg/s:', (received / duration).toFixed(2));
+          connection.close();
+        }
+      }
+    },
+    { noAck: false }
+  );
+
+  const sendInterval = setInterval(() => {
+    for (let i = 0; i < rate && sent < count; i++) {
+      const payload = { id: sent, ts: Date.now() };
+      channel.sendToQueue(queue, Buffer.from(JSON.stringify(payload)), {
+        persistent: true,
+      });
+      sent++;
     }
-  }, { noAck: false });
-
-  console.log('Waiting for message...');
+    if (sent >= count) {
+      clearInterval(sendInterval);
+      console.log(`Sent ${sent} messages, waiting for receipts...`);
+    }
+  }, 1000);
 }
 
 main().catch(err => {

--- a/sqs_test.js
+++ b/sqs_test.js
@@ -5,6 +5,7 @@ const {
   ReceiveMessageCommand,
   DeleteMessageCommand,
 } = require("@aws-sdk/client-sqs");
+const { percentile } = require('./util');
 
 async function main() {
   const queueName = process.env.SQS_QUEUE || "test-queue";
@@ -30,23 +31,76 @@ async function main() {
     endpoint || "default"
   );
 
-  const { QueueUrl } = await client.send(
-    new CreateQueueCommand({ QueueName: queueName })
+  const rate = parseInt(process.env.MESSAGE_RATE || '100', 10);
+  const durationSec = parseInt(process.env.TEST_DURATION_SEC || '600', 10);
+  const count = parseInt(
+    process.env.MESSAGE_COUNT || (rate * durationSec).toString(),
+    10
   );
-  const message = "Hello SQS";
-  await client.send(new SendMessageCommand({ QueueUrl, MessageBody: message }));
-  console.log("Sent:", message);
 
-  const { Messages } = await client.send(
-    new ReceiveMessageCommand({ QueueUrl, WaitTimeSeconds: 5 })
-  );
-  if (Messages && Messages.length > 0) {
-    const m = Messages[0];
-    console.log("Received:", m.Body);
-    await client.send(
-      new DeleteMessageCommand({ QueueUrl, ReceiptHandle: m.ReceiptHandle })
+  let QueueUrl;
+  try {
+    const result = await client.send(
+      new CreateQueueCommand({ QueueName: queueName })
     );
+    QueueUrl = result.QueueUrl;
+    console.log('SQS available');
+  } catch (err) {
+    console.error('SQS unavailable', err);
+    return;
   }
+
+  let sent = 0;
+  let received = 0;
+  const latencies = [];
+  const seen = new Set();
+  let duplicates = 0;
+
+  const start = Date.now();
+
+  const sendInterval = setInterval(async () => {
+    const promises = [];
+    for (let i = 0; i < rate && sent < count; i++) {
+      const payload = { id: sent, ts: Date.now() };
+      promises.push(
+        client.send(
+          new SendMessageCommand({
+            QueueUrl,
+            MessageBody: JSON.stringify(payload),
+          })
+        )
+      );
+      sent++;
+    }
+    await Promise.all(promises);
+    if (sent >= count) {
+      clearInterval(sendInterval);
+      console.log(`Sent ${sent} messages, waiting for receipts...`);
+    }
+  }, 1000);
+
+  while (received < count) {
+    const { Messages } = await client.send(
+      new ReceiveMessageCommand({ QueueUrl, WaitTimeSeconds: 1, MaxNumberOfMessages: 10 })
+    );
+    if (Messages) {
+      for (const m of Messages) {
+        const { id, ts } = JSON.parse(m.Body);
+        const now = Date.now();
+        latencies.push(now - ts);
+        if (seen.has(id)) duplicates++; else seen.add(id);
+        received++;
+        await client.send(
+          new DeleteMessageCommand({ QueueUrl, ReceiptHandle: m.ReceiptHandle })
+        );
+      }
+    }
+  }
+
+  const duration = (Date.now() - start) / 1000;
+  console.log('p95 latency ms:', percentile(latencies, 95));
+  console.log('duplicates:', duplicates);
+  console.log('throughput msg/s:', (received / duration).toFixed(2));
 }
 
 main().catch((err) => {

--- a/util.js
+++ b/util.js
@@ -1,0 +1,7 @@
+function percentile(arr, p) {
+  if (arr.length === 0) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  const idx = Math.floor((p / 100) * (sorted.length - 1));
+  return sorted[idx];
+}
+module.exports = { percentile };


### PR DESCRIPTION
## Summary
- allow each queue test to send messages at a configurable rate over a fixed duration
- document `MESSAGE_RATE` and `TEST_DURATION_SEC` variables

## Testing
- `npm install`
- `node rabbitmq_test.js` *(fails: ECONNREFUSED)*
- `node nats_test.js` *(fails: CONNECTION_REFUSED)*
- `node sqs_test.js` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_686698355e9c8328a67d1067db4d3825