### PR TITLE
Add Kafka example

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,3 +4,4 @@ AWS_REGION=us-east-1
 SQS_ENDPOINT=http://localhost:4566
 AWS_ACCESS_KEY_ID=test
 AWS_SECRET_ACCESS_KEY=test
+KAFKA_BROKERS=localhost:9092

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # poc-queues-availability
 
-This repository contains simple scripts to test different messaging technologies (RabbitMQ, AWS SQS and NATS). Each script sends and receives a single message demonstrating basic connectivity.
+This repository contains simple scripts to test different messaging technologies (RabbitMQ, AWS SQS, NATS and Kafka). Each script sends and receives a single message demonstrating basic connectivity.
 
 ## Requirements
 
@@ -19,11 +19,12 @@ You can run the example scripts via npm:
 npm run rabbitmq   # test RabbitMQ
 npm run sqs        # test SQS
 npm run nats       # test NATS
+npm run kafka      # test Kafka
 ```
 
 ## Running Messaging Services Locally
 
-Start RabbitMQ, NATS and a local SQS implementation using Docker Compose:
+Start RabbitMQ, NATS, Kafka and a local SQS implementation using Docker Compose:
 
 ```bash
 docker-compose up -d
@@ -34,12 +35,14 @@ This will expose the following ports:
 - RabbitMQ: `5672` (AMQP) and `15672` (management UI)
 - NATS: `4222`
 - LocalStack (SQS): `4566`
+- Kafka: `9092`
 
 Set the following environment variables when running the scripts to connect to
 these local services:
 
 - `RABBITMQ_URL=amqp://localhost`
 - `NATS_URL=nats://localhost:4222`
+- `KAFKA_BROKERS=localhost:9092`
 - `AWS_REGION=us-east-1`
 - `SQS_ENDPOINT=http://localhost:4566`
 - optionally `AWS_ACCESS_KEY_ID=test` and `AWS_SECRET_ACCESS_KEY=test`
@@ -75,6 +78,16 @@ Run (you can override `MESSAGE_RATE`, `TEST_DURATION_SEC` and `FAIL_AFTER_SEC`):
 
 ```bash
 node nats_test.js
+```
+
+## Kafka Test
+
+Set `KAFKA_BROKERS` to your Kafka brokers (for example from Amazon MSK or Confluent Cloud) and optionally `KAFKA_TOPIC`.
+
+Run (you can override `MESSAGE_RATE`, `TEST_DURATION_SEC` and `FAIL_AFTER_SEC`):
+
+```bash
+node kafka_test.js
 ```
 
 ## Pulumi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,11 @@ services:
       - SERVICES=sqs
     ports:
       - "4566:4566"
+  kafka:
+    image: bitnami/kafka:latest
+    environment:
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
+    ports:
+      - "9092:9092"

--- a/kafka_test.js
+++ b/kafka_test.js
@@ -1,0 +1,81 @@
+const { Kafka } = require('kafkajs');
+const { percentile } = require('./util');
+
+async function main() {
+  const brokers = (process.env.KAFKA_BROKERS || 'localhost:9092').split(',');
+  const topic = process.env.KAFKA_TOPIC || 'test';
+
+  const rate = parseInt(process.env.MESSAGE_RATE || '100', 10);
+  const durationSec = parseInt(process.env.TEST_DURATION_SEC || '600', 10);
+  const count = parseInt(
+    process.env.MESSAGE_COUNT || (rate * durationSec).toString(),
+    10
+  );
+  const failAfter = parseInt(process.env.FAIL_AFTER_SEC || '0', 10);
+
+  const kafka = new Kafka({ clientId: 'poc-client', brokers });
+  const producer = kafka.producer();
+  const consumer = kafka.consumer({ groupId: 'poc-group' });
+
+  try {
+    await producer.connect();
+    await consumer.connect();
+    console.log('Kafka available');
+  } catch (err) {
+    console.error('Kafka unavailable', err);
+    return;
+  }
+
+  await consumer.subscribe({ topic, fromBeginning: true });
+
+  let sent = 0;
+  let received = 0;
+  const latencies = [];
+  const seen = new Set();
+  let duplicates = 0;
+
+  const start = Date.now();
+
+  if (failAfter > 0) {
+    setTimeout(() => {
+      console.log('Simulating Kafka failure: disconnecting producer');
+      producer.disconnect().catch(() => {});
+    }, failAfter * 1000);
+  }
+
+  await consumer.run({
+    eachMessage: async ({ message }) => {
+      if (!message.value) return;
+      const { id, ts } = JSON.parse(message.value.toString());
+      const now = Date.now();
+      latencies.push(now - ts);
+      if (seen.has(id)) duplicates++; else seen.add(id);
+      received++;
+      if (received === count) {
+        const duration = (now - start) / 1000;
+        console.log('p95 latency ms:', percentile(latencies, 95));
+        console.log('duplicates:', duplicates);
+        console.log('throughput msg/s:', (received / duration).toFixed(2));
+        await producer.disconnect();
+        await consumer.disconnect();
+      }
+    },
+  });
+
+  const sendInterval = setInterval(async () => {
+    for (let i = 0; i < rate && sent < count; i++) {
+      const payload = { id: sent, ts: Date.now() };
+      await producer.send({ topic, messages: [{ value: JSON.stringify(payload) }] });
+      sent++;
+    }
+    if (sent >= count) {
+      clearInterval(sendInterval);
+      console.log(`Sent ${sent} messages, waiting for receipts...`);
+    }
+  }, 1000);
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@pulumi/aws": "^6.83.0",
         "@pulumi/pulumi": "^3.181.0",
         "amqplib": "^0.10.8",
+        "kafkajs": "^2.2.4",
         "nats": "^2.29.3"
       }
     },
@@ -3110,6 +3111,15 @@
       "resolved": "https://registry.npmjs.org/just-diff-apply/-/just-diff-apply-5.5.0.tgz",
       "integrity": "sha512-OYTthRfSh55WOItVqwpefPtNt2VdKsq5AnAK6apdtR6yCH8pr0CmSr710J0Mf+WdQy7K/OzMy7K2MgAfdQURDw==",
       "license": "MIT"
+    },
+    "node_modules/kafkajs": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.4.tgz",
+      "integrity": "sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "nats": "node nats_test.js",
     "rabbitmq": "node rabbitmq_test.js",
-    "sqs": "node sqs_test.js"
+    "sqs": "node sqs_test.js",
+    "kafka": "node kafka_test.js"
   },
   "keywords": [],
   "author": "",
@@ -17,6 +18,7 @@
     "@pulumi/aws": "^6.83.0",
     "@pulumi/pulumi": "^3.181.0",
     "amqplib": "^0.10.8",
-    "nats": "^2.29.3"
+    "nats": "^2.29.3",
+    "kafkajs": "^2.2.4"
   }
 }


### PR DESCRIPTION
## Summary
- add Kafka test with `kafkajs`
- support Kafka in Docker Compose and README instructions
- document KAFKA_BROKERS env var
- expose npm script for Kafka

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6866d30a08a88328aed64b133ec066f7