### PR TITLE
Add Kafka to BigQuery flow test

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ node kafka_test.js
 
 Use `npm run bigquery` to insert events directly into Google BigQuery. Set `BIGQUERY_DATASET` and `BIGQUERY_TABLE` along with your credentials. The script reports basic latency and throughput metrics.
 
+## Kafka to BigQuery Flow
+
+Run `npm run kafka-bigquery` to publish messages to Kafka and immediately insert
+them into BigQuery. Configure the same environment variables as `kafka_test.js`
+for Kafka connectivity plus `BIGQUERY_DATASET` and `BIGQUERY_TABLE` for the
+destination table. The message rate and duration are controlled via
+`MESSAGE_RATE`, `TEST_DURATION_SEC` and `MESSAGE_COUNT`.
+
 ## Redpanda & Redpanda Connect
 
 Spin up the `redpanda` service from `docker-compose.yml` and run `kafka_test.js` with `KAFKA_BROKERS=localhost:9094`. Redpanda Connect can forward these events to sinks such as BigQuery.

--- a/kafka_bigquery.js
+++ b/kafka_bigquery.js
@@ -1,0 +1,94 @@
+const { Kafka, Partitioners } = require('kafkajs');
+const { BigQuery } = require('@google-cloud/bigquery');
+const { percentile } = require('./util');
+
+async function main() {
+  const topic = process.env.KAFKA_TOPIC || 'test';
+  const datasetId = process.env.BIGQUERY_DATASET || 'test';
+  const tableId = process.env.BIGQUERY_TABLE || 'messages';
+  const projectId = process.env.BQ_PROJECT_ID;
+
+  const rate = parseInt(process.env.MESSAGE_RATE || '100', 10);
+  const durationSec = parseInt(process.env.TEST_DURATION_SEC || '600', 10);
+  const count = parseInt(
+    process.env.MESSAGE_COUNT || (rate * durationSec).toString(),
+    10
+  );
+
+  const bigquery = new BigQuery(projectId ? { projectId } : {});
+  const table = bigquery.dataset(datasetId).table(tableId);
+
+  const brokers = (process.env.KAFKA_BROKERS || '127.0.0.1:9092')
+    .split(',')
+    .map((b) => b.trim());
+
+  const kafka = new Kafka({
+    clientId: 'poc-client',
+    brokers,
+    ssl: process.env.KAFKA_SSL === 'true',
+    sasl: process.env.KAFKA_SASL_USER && {
+      mechanism: 'plain',
+      username: process.env.KAFKA_SASL_USER,
+      password: process.env.KAFKA_SASL_PASS,
+    },
+    createPartitioner: Partitioners.LegacyPartitioner,
+  });
+
+  const producer = kafka.producer({
+    createPartitioner: Partitioners.LegacyPartitioner,
+  });
+  const consumer = kafka.consumer({ groupId: 'poc-group' });
+
+  await producer.connect();
+  await consumer.connect();
+  await consumer.subscribe({ topic, fromBeginning: true });
+  console.log('Kafka available, starting test');
+
+  let sent = 0;
+  let inserted = 0;
+  const latencies = [];
+
+  const start = Date.now();
+
+  consumer.run({
+    eachMessage: async ({ message }) => {
+      if (!message.value) return;
+      const payload = JSON.parse(message.value.toString());
+      const insertStart = Date.now();
+      try {
+        await table.insert([payload]);
+        latencies.push(Date.now() - payload.ts);
+      } catch (err) {
+        console.error('BigQuery insert error:', err.errors || err);
+      }
+      inserted++;
+      if (inserted === count) {
+        const duration = (Date.now() - start) / 1000;
+        console.log('p95 latency ms:', percentile(latencies, 95));
+        console.log('throughput msg/s:', (inserted / duration).toFixed(2));
+        await producer.disconnect();
+        await consumer.disconnect();
+      }
+    },
+  });
+
+  const sendInterval = setInterval(async () => {
+    for (let i = 0; i < rate && sent < count; i++) {
+      const payload = { id: sent, ts: Date.now() };
+      await producer.send({
+        topic,
+        messages: [{ value: JSON.stringify(payload) }],
+      });
+      sent++;
+    }
+    if (sent >= count) {
+      clearInterval(sendInterval);
+      console.log(`Sent ${sent} messages, waiting for processing...`);
+    }
+  }, 1000);
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "rabbitmq": "node rabbitmq_test.js",
     "sqs": "node sqs_test.js",
     "kafka": "node kafka_test.js",
-    "bigquery": "node bigquery_test.js"
+    "bigquery": "node bigquery_test.js",
+    "kafka-bigquery": "node kafka_bigquery.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `kafka_bigquery.js` to publish to Kafka and insert into BigQuery
- expose npm script `kafka-bigquery`
- document Kafka to BigQuery flow in README

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*
- `node kafka_bigquery.js` *(fails: connection refused because no Kafka broker running)*

------
https://chatgpt.com/codex/tasks/task_e_68680eca95948328b909f476925ac68a