### PR TITLE
Add RabbitMQ edge function and Pulumi stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,4 @@ The compose file also provides a `nodered` service on port `1880`. Build flows t
 The `infrastructure/` folder contains a small Pulumi program that provisions an SQS queue and a RabbitMQ broker using AmazonMQ. Initialize a Pulumi stack and run `pulumi up` to deploy (AWS credentials required).
 
 A second program `kafka_redpanda.ts` creates Docker containers for Kafka and Redpanda using Pulumi. This allows you to spin up the local broker stack with `pulumi up` instead of using Docker Compose.
+An additional program `edge-function.ts` provisions a Lambda function that forwards tracking events to RabbitMQ.

--- a/edge-lambda/index.js
+++ b/edge-lambda/index.js
@@ -1,0 +1,40 @@
+import amqp from 'amqplib';
+
+let connection;
+let channel;
+
+const QUEUE = process.env.RABBITMQ_QUEUE || 'tracking_events';
+const URL = process.env.RABBITMQ_URL || 'amqp://localhost';
+
+async function init() {
+  if (!connection) {
+    connection = await amqp.connect(URL);
+    channel = await connection.createChannel();
+    await channel.assertQueue(QUEUE, { durable: true });
+  }
+}
+
+export const handler = async (event) => {
+  try {
+    await init();
+  } catch (err) {
+    console.error('RabbitMQ connection error', err);
+    return { statusCode: 500, body: 'RabbitMQ connection error' };
+  }
+
+  let messages;
+  try {
+    const body = event.body || '{}';
+    const parsed = JSON.parse(body);
+    messages = Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    return { statusCode: 400, body: 'Invalid JSON' };
+  }
+
+  for (const msg of messages) {
+    const payload = Buffer.from(JSON.stringify(msg));
+    channel.sendToQueue(QUEUE, payload, { persistent: true });
+  }
+
+  return { statusCode: 200, body: JSON.stringify({ sent: messages.length }) };
+};

--- a/edge-lambda/package.json
+++ b/edge-lambda/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/infrastructure/edge-function.ts
+++ b/infrastructure/edge-function.ts
@@ -1,0 +1,41 @@
+import * as aws from '@pulumi/aws';
+import * as pulumi from '@pulumi/pulumi';
+
+// RabbitMQ broker using AmazonMQ
+export const broker = new aws.mq.Broker('edgeBroker', {
+    brokerName: 'edge-broker',
+    engineType: 'RabbitMQ',
+    engineVersion: '3.10.20',
+    hostInstanceType: 'mq.t3.micro',
+    publiclyAccessible: true,
+    users: [{ username: 'user', password: 'Password123!' }],
+});
+
+const role = new aws.iam.Role('edgeLambdaRole', {
+    assumeRolePolicy: aws.iam.assumeRolePolicyForPrincipal({
+        Service: 'lambda.amazonaws.com',
+    }),
+});
+
+new aws.iam.RolePolicyAttachment('edgeLambdaBasic', {
+    role: role.name,
+    policyArn: aws.iam.ManagedPolicies.AWSLambdaBasicExecutionRole,
+});
+
+const lambda = new aws.lambda.Function('rabbitEdgeHandler', {
+    runtime: aws.lambda.Runtime.NodeJS20dX, // Node 20
+    role: role.arn,
+    handler: 'index.handler',
+    code: new pulumi.asset.AssetArchive({
+        '.': new pulumi.asset.FileArchive('../edge-lambda'),
+    }),
+    environment: {
+        variables: {
+            RABBITMQ_URL: broker.amqpEndpoints.apply(e => e[0]),
+            RABBITMQ_QUEUE: 'tracking_events',
+        },
+    },
+});
+
+export const lambdaArn = lambda.arn;
+export const brokerEndpoint = broker.instances.apply(i => i[0].consoleUrl);


### PR DESCRIPTION
## Summary
- create `edge-lambda/index.js` Lambda@Edge handler to push batches of events to RabbitMQ
- add Pulumi program `edge-function.ts` to deploy the Lambda and RabbitMQ broker
- document new Pulumi program in README

## Testing
- `node --check edge-lambda/index.js`

------
https://chatgpt.com/codex/tasks/task_e_686d28200c9083289c35918461ccd13e